### PR TITLE
allow http client overriding and disable client keep-alives by default

### DIFF
--- a/client/flow_client.go
+++ b/client/flow_client.go
@@ -6,6 +6,8 @@ package client
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"net/http"
+
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 
@@ -44,9 +46,8 @@ func NewHTTPClientWithConfig(formats strfmt.Registry, cfg *TransportConfig) *Flo
 	if cfg == nil {
 		cfg = DefaultTransportConfig()
 	}
-
 	// create transport and client
-	transport := httptransport.New(cfg.Host, cfg.BasePath, cfg.Schemes)
+	transport := httptransport.NewWithClient(cfg.Host, cfg.BasePath, cfg.Schemes, cfg.HTTPClient)
 	return New(transport, formats)
 }
 
@@ -73,9 +74,10 @@ func DefaultTransportConfig() *TransportConfig {
 // TransportConfig contains the transport related info,
 // found in the meta section of the spec file.
 type TransportConfig struct {
-	Host     string
-	BasePath string
-	Schemes  []string
+	Host       string
+	BasePath   string
+	Schemes    []string
+	HTTPClient *http.Client
 }
 
 // WithHost overrides the default host,
@@ -96,6 +98,12 @@ func (cfg *TransportConfig) WithBasePath(basePath string) *TransportConfig {
 // provided by the meta section of the spec file.
 func (cfg *TransportConfig) WithSchemes(schemes []string) *TransportConfig {
 	cfg.Schemes = schemes
+	return cfg
+}
+
+// WithHTTPClient overrides the default HTTP client
+func (cfg *TransportConfig) WithHTTPClient(client *http.Client) *TransportConfig {
+	cfg.HTTPClient = client
 	return cfg
 }
 

--- a/flows.go
+++ b/flows.go
@@ -59,7 +59,16 @@ type FlowFuture interface {
 }
 
 var debugMu uint32 // atomics are faster than mu lock/unlock
+var httpClient *http.Client
 
+// UseHTTPClient allows the default http client to be overriden
+// for calls to the flow service. This function must be called
+// prior to flows.WithFlow to take effect (e.g. from an init method)
+func UseHTTPClient(client *http.Client) {
+	httpClient = client
+}
+
+// Debug enables internal library debugging
 func Debug(withDebug bool) {
 	// go won't cast bool to uint32, you better believe it
 	var bint uint32
@@ -70,6 +79,7 @@ func Debug(withDebug bool) {
 	debug("Enabled debugging")
 }
 
+// Log to stderr when Debug mode is enabled
 func Log(msg string) {
 	debug(msg)
 }
@@ -86,7 +96,7 @@ func getActionKey(actionFunc interface{}) string {
 	return runtime.FuncForPC(reflect.ValueOf(actionFunc).Pointer()).Name()
 }
 
-// registers a go function so it can be used as an action
+// RegisterAction registers a go function so it can be used as an action
 // in a flow stage
 func RegisterAction(actionFunc interface{}) {
 	if reflect.TypeOf(actionFunc).Kind() != reflect.Func {


### PR DESCRIPTION
Some users reported issues with outgoing requests to the flow service being interrupted with an EOF. This could be related to the client using HTTP persistent connections, which are then unexpectedly closed on the server side. This PR disables keep-alives in the client requests, and allows HTTP clients to be overridden by library users for full control.